### PR TITLE
Allow Objects, Bump Node Version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
   "presets": [
     [
       "env", {
-        "targets": { "node": "6" }
+        "targets": { "node": "8" }
       }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "gatsby-source-craftcms",
   "description": "Gatsby source plugin for building websites using the CraftCMS as a data source.",
   "keywords": [

--- a/src/util.js
+++ b/src/util.js
@@ -64,8 +64,6 @@ export const getCreateCraftNode = (createNode, reporter, key) => (queryResultNod
 }
 
 export const createNodes = (createNode, reporter) => (value, key) => {
-  // Console.log(key, value)
-  
   const createCraftNode = getCreateCraftNode(createNode, reporter, key)
   
   if(Array.isArray(value)) {

--- a/src/util.js
+++ b/src/util.js
@@ -31,35 +31,48 @@ export const assembleQueries = compose(
   path([`__type`, `possibleTypes`])
 );
 
+
+
+export const getCreateCraftNode = (createNode, reporter, key) => (queryResultNode) => {
+  const {id, ...fields} = queryResultNode;
+  const jsonNode = JSON.stringify(queryResultNode);
+  const gatsbyNode = {
+    id: id || key,
+    ...fields,
+    parent: `${SOURCE_NAME}_${key}`,
+    children: [],
+    internal: {
+      type: extractTypeName(key),
+      content: jsonNode,
+      contentDigest: crypto
+        .createHash(`md5`)
+        .update(jsonNode)
+        .digest(`hex`)
+    }
+  };
+  if (DEBUG_MODE) {
+    const jsonFields = JSON.stringify(fields);
+    const jsonGatsbyNode = JSON.stringify(gatsbyNode);
+    reporter.info(`  processing node: ${jsonNode}`);
+    reporter.info(`    node id ${id}`);
+    reporter.info(`    node fields: ${jsonFields}`);
+    reporter.info(`    gatsby node: ${jsonGatsbyNode}`);
+  }
+  
+  createNode(gatsbyNode);
+  
+}
+
 export const createNodes = (createNode, reporter) => (value, key) => {
   // Console.log(key, value)
-  forEach(queryResultNode => {
-    const {id, ...fields} = queryResultNode;
-    const jsonNode = JSON.stringify(queryResultNode);
-    const gatsbyNode = {
-      id,
-      ...fields,
-      parent: `${SOURCE_NAME}_${key}`,
-      children: [],
-      internal: {
-        type: extractTypeName(key),
-        content: jsonNode,
-        contentDigest: crypto
-          .createHash(`md5`)
-          .update(jsonNode)
-          .digest(`hex`)
-      }
-    };
-
-    if (DEBUG_MODE) {
-      const jsonFields = JSON.stringify(fields);
-      const jsonGatsbyNode = JSON.stringify(gatsbyNode);
-      reporter.info(`  processing node: ${jsonNode}`);
-      reporter.info(`    node id ${id}`);
-      reporter.info(`    node fields: ${jsonFields}`);
-      reporter.info(`    gatsby node: ${jsonGatsbyNode}`);
-    }
-
-    createNode(gatsbyNode);
-  }, value);
+  
+  const createCraftNode = getCreateCraftNode(createNode, reporter, key)
+  
+  if(Array.isArray(value)) {
+    forEach(createCraftNode, value);
+  } else if(typeof value === 'object') {
+    createCraftNode(value)
+  }
+  
+  
 };


### PR DESCRIPTION
bump node requirement, allow objects (namely global) to be imported into the gatsby graphql schema